### PR TITLE
Free the spi_device pointer before early returns.

### DIFF
--- a/lib/libloragw/src/loragw_spi.native.c
+++ b/lib/libloragw/src/loragw_spi.native.c
@@ -81,6 +81,7 @@ int lgw_spi_open(void **spi_target_ptr) {
     dev = open(SPI_DEV_PATH, O_RDWR);
     if (dev < 0) {
         DEBUG_PRINTF("ERROR: failed to open SPI device %s\n", SPI_DEV_PATH);
+        free(spi_device);
         return LGW_SPI_ERROR;
     }
 
@@ -124,6 +125,7 @@ int lgw_spi_open(void **spi_target_ptr) {
     if ((a < 0) || (b < 0)) {
         DEBUG_MSG("ERROR: SPI PORT FAIL TO SET 8 BITS-PER-WORD\n");
         close(dev);
+        free(spi_device);
         return LGW_SPI_ERROR;
     }
 


### PR DESCRIPTION
The allocated memory for spi_device was not free()'d in the case where the SPI device cannot be opened, nor in the case where the SPI port cannot be set to 8 bits per word.

This results in potential memory leaks, which are fixed by free()'ing the spi_device pointer before returning from the aforementioned execution paths.
